### PR TITLE
fix flaky behavior in the test

### DIFF
--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubTemplateTests.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.core.ApiService;
 import com.google.api.core.SettableApiFuture;
@@ -79,8 +80,10 @@ class PubSubTemplateTests {
   private PubSubPublisherTemplate createPublisherTemplate() {
     PubSubPublisherTemplate pubSubPublisherTemplate =
         new PubSubPublisherTemplate(this.mockPublisherFactory);
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
     pubSubPublisherTemplate.setMessageConverter(
-        new JacksonPubSubMessageConverter(new ObjectMapper()));
+        new JacksonPubSubMessageConverter(objectMapper));
     return pubSubPublisherTemplate;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the test case `com.google.cloud.spring.pubsub.core.PubSubTemplateTests`, we configure the `ObjectMapper` to sort the keys when calling `this.objectMapper.writeValueAsBytes(payload)` in the method `JacksonPubSubMessageConverter.toPubSubMessage`.

## Why are the changes needed?
There is an implementation-dependent operation `this.objectMapper.writeValueAsBytes(payload)` in `JacksonPubSubMessageConverter.toPubSubMessage`, which is identified by the engine [NonDex](https://github.com/TestingResearchIllinois/NonDex).

In the test `PubSubTemplateTests#testPublish_Object`, we assert the value `message.getData().toStringUtf8()` with the json string in particular order, which would not be guaranteed by `ObjectMapper`.

There are possible orders as follow.
```
# possible order 1:
{"@class":"com.google.cloud.spring.pubsub.core.test.allowed.AllowedPayload","name":"allowed","value":12345}
# possible order 2:
{"@class":"com.google.cloud.spring.pubsub.core.test.allowed.AllowedPayload","value":12345,"name":"allowed"}
```

Error message shown in NonDex engine is as follow:
```
[ERROR] Failures:
[ERROR]   PubSubTemplateTests.testPublish_Object:143->lambda$testPublish_Object$0:134
expected: "{"@class":"com.google.cloud.spring.pubsub.core.test.allowed.AllowedPayload","name":"allowed","value":12345}"
 but was: "{"@class":"com.google.cloud.spring.pubsub.core.test.allowed.AllowedPayload","value":12345,"name":"allowed"}"
```

As a result, it would be better to change the configuration by setting `MapperFeature` which is defined in [jackson](https://github.com/FasterXML/jackson-databind/blob/f72c3e0167b6c5c0d76e2368258605f73620a661/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java#L707)

## Does this PR introduce any user-facing change?
No

## Is the change a dependency upgrade?
No

## How was this patch tested?
Test Environment:
```
openjdk version "17.0.8.1"
Apache Maven 3.8.8
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```

Set up the NonDex engine:
```
git clone https://github.com/kaiyaok2/NonDex
cd NonDex
git checkout support_java_17
mvn clean install -DskipTests
```

Run the unit test using NonDex with the following command.
```
cd $test_project_dir
mvn -pl spring-cloud-gcp-pubsub edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=com.google.cloud.spring.pubsub.core.PubSubTemplateTests#testPublish_Object -Drat.skip=true -DnondexRuns=20
```

Please let me know if you have any concerns.


