### PR TITLE
adjust assertion methods to fix flaky behaviors in writeJsonArrayTest

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -61,8 +61,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /** Tests for the conversion and mapping of entities for write. */
 class ConverterAwareMappingSpannerEntityWriterTests {
@@ -364,7 +367,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
   }
 
   @Test
-  void writeJsonArrayTest() {
+  void writeJsonArrayTest() throws JSONException {
     TestEntities.Params parameters = new TestEntities.Params("some value", "some other value");
     TestEntities.TestEntityJsonArray testEntity = new TestEntities.TestEntityJsonArray("id1", Arrays.asList(parameters, parameters));
 
@@ -376,12 +379,17 @@ class ConverterAwareMappingSpannerEntityWriterTests {
 
     this.spannerEntityWriter.write(testEntity, writeBuilder::set);
 
-    List<String> stringList = new ArrayList<>();
-    stringList.add("{\"p1\":\"some value\",\"p2\":\"some other value\"}");
-    stringList.add("{\"p1\":\"some value\",\"p2\":\"some other value\"}");
-
+    ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
     verify(valueBinder).to(testEntity.id);
-    verify(valueBinder).toJsonArray(stringList);
+    verify(valueBinder).toJsonArray(captor.capture());
+    JSONAssert.assertEquals(
+        "{\"p1\":\"some value\",\"p2\":\"some other value\"}",
+        captor.getValue().get(0),
+        true);
+    JSONAssert.assertEquals(
+        "{\"p1\":\"some value\",\"p2\":\"some other value\"}",
+        captor.getValue().get(1),
+        true);
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -334,7 +334,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
   }
 
   @Test
-  void writeJsonTest() {
+  void writeJsonTest() throws JSONException {
     TestEntities.Params parameters = new TestEntities.Params("some value", "some other value");
     TestEntities.TestEntityJson testEntity = new TestEntities.TestEntityJson("id1", parameters);
 
@@ -346,8 +346,15 @@ class ConverterAwareMappingSpannerEntityWriterTests {
 
     this.spannerEntityWriter.write(testEntity, writeBuilder::set);
 
-    verify(valueBinder).to(testEntity.id);
-    verify(valueBinder).to(Value.json("{\"p1\":\"some value\",\"p2\":\"some other value\"}"));
+    ArgumentCaptor<String> captor1 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Value> captor2 = ArgumentCaptor.forClass(Value.class);
+    verify(valueBinder).to(captor1.capture());
+    verify(valueBinder).to(captor2.capture());
+    assertThat(captor1.getValue()).isEqualTo(testEntity.id);
+    JSONAssert.assertEquals(
+        "{\"p1\":\"some value\",\"p2\":\"some other value\"}",
+        captor2.getValue().getString(),
+        true);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the test case `com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriterTests#writeJsonArrayTest` and `com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriterTests#writeJsonTest`, we changed the assertion methods on the array of JSON elements.

We used `org.mockito.ArgumentCaptor` to extract the argument and `org.skyscreamer.jsonassert.JSONAssert` to assert the JSON elements.

## Why are the changes needed?
There is an implementation-dependent operation in `ConverterAwareMappingSpannerEntityWriter#convertJsonToValue`, which is identified by the engine [NonDex](https://github.com/TestingResearchIllinois/NonDex).

When setting json object in `ConverterAwareMappingSpannerEntityWriter` will use `convertJsonToValue`.
https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/d7a10f56b65cb21f31b6f398773c71380f22abf2/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java#L375

However, in the test `ConverterAwareMappingSpannerEntityWriterTests#writeJsonArrayTest` and `ConverterAwareMappingSpannerEntityWriterTests#writeJsonTest`, we assert the json argument string in particular order, which would not be guaranteed in different Gson/Java version.

For example, there are possible orders in the argument of `toJsonArray` as below.
```
# possible order 1:
[{"p1":"some value","p2":"some other value"}, {"p1":"some value","p2":"some other value"}]
# possible order 2:
[{"p2":"some other value","p1":"some value"}, {"p2":"some other value","p1":"some value"}]
```

Error message shown in NonDex engine is as below:
```
[ERROR] com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriterTests.writeJsonArrayTest -- Time elapsed: 0.029 s <<< FAILURE!
Argument(s) are different! Wanted:
valueBinder.toJsonArray(
    [{"p1":"some value","p2":"some other value"}, {"p1":"some value","p2":"some other value"}]
);
-> at com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriterTests.writeJsonArrayTest(ConverterAwareMappingSpannerEntityWriterTests.java:384)
Actual invocations have different arguments:
valueBinder.toJsonArray(
    [{"p2":"some other value","p1":"some value"}, {"p2":"some other value","p1":"some value"}]
);
```

As a result, it would be better to change the assertion methods to prevent from the flaky behaviors.

## Does this PR introduce any user-facing change?
No

## Is the change a dependency upgrade?
No

## How was this patch tested?
Test Environment:
```
openjdk version "17.0.8.1"
Apache Maven 3.8.8
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```

Set up the NonDex engine:
```
git clone https://github.com/kaiyaok2/NonDex
cd NonDex
git checkout support_java_17
mvn clean install -DskipTests
```

Run the unit test using NonDex with the following command.
```
cd $test_project_dir
mvn -pl spring-cloud-gcp-data-spanner edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriterTests#writeJsonArrayTest -Drat.skip=true -DnondexRuns=10 |& tee mvn-test-writeJsonArrayTest-$(date +%s).log
```

Please let me know if you have any concerns.


